### PR TITLE
Add opt-in feature to write module imports compatible with 2018 edition.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 serde-xml-rs = "0.2.1"
+
+[features]
+default = []
+use-2018-edition = []

--- a/src/rust.rs
+++ b/src/rust.rs
@@ -1264,7 +1264,8 @@ use std::sync::Arc;
 use std::sync::atomic::{{AtomicPtr, Ordering}};
 use std::ptr::null;
 
-use {}::*;",
+use {}{}::*;",
+        if cfg!(feature = "use-2018-edition") { "crate::" } else { "" },
         conf.rust.implementation_module
     )?;
 
@@ -1518,8 +1519,9 @@ pub fn write_implementation(conf: &Config) -> Result<()> {
         "#![allow(unused_imports)]
 #![allow(unused_variables)]
 #![allow(dead_code)]
-use {}::*;
+use {}{}::*;
 ",
+        if cfg!(feature = "use-2018-edition") { "crate::" } else { "" },
         conf.rust.interface_module
     )?;
 


### PR DESCRIPTION
After enabling 2018 edition on my cargo project, the use statements
generated in the interface module no longer resolve.

Prefixing module paths with `crate::` brings things back into alignment.

Unsure if this is how you'd like to approach the issue, but I'm happy to revise the patch based on your feedback.

Thanks for all your work on this, and for taking extra steps to make it more cargo-centric. We've got a fun project cooking at @LaikaStudios with hopes to make use of this crate.